### PR TITLE
No generic exception rule test

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/rules/NoGenericExceptionRuleTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/NoGenericExceptionRuleTest.java
@@ -1,0 +1,38 @@
+package com.societegenerale.commons.plugin.rules;
+
+import com.societegenerale.commons.plugin.service.ScopePathProvider;
+import com.societegenerale.commons.plugin.utils.ArchUtils;
+import com.tngtech.archunit.library.GeneralCodingRules;
+
+/**
+ * It's important to throw specific exceptions than generic exceptions in order
+ * to get the real source of what's going wrong. Thus, it's easy to find
+ * solutions.
+ * 
+ * To make you better understand, these 2 links will help you :
+ * 
+ * 
+ * 
+ * @see <a href=
+ *      "https://wiki.c2.com/?DontThrowGenericExceptions">DontThrowGenericExceptions</a>
+ * 
+ * 
+ * @see <a href=
+ *      "https://stackoverflow.com/questions/7959461/throwing-generic-exception-discouraged">throwing-generic-exception-discouraged</a>
+ * 
+ * 
+ */
+
+public class NoGenericExceptionRuleTest implements ArchRuleTest {
+
+	public static final String NO_GENERIC_EXCEPTION_VIOLATION_MESSAGE = "it's important to throw specific exceptions than generic exceptions in order to get the real source of what's going wrong. Thus, it's easy to find solutions.";
+
+	@Override
+	public void execute(String path, ScopePathProvider scopePathProvider) {
+
+		GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS.because(NO_GENERIC_EXCEPTION_VIOLATION_MESSAGE)
+				.check(ArchUtils.importAllClassesInPackage(path, scopePathProvider.getMainClassesPath()));
+
+	}
+
+}

--- a/src/test/java/com/societegenerale/aut/test/ObjectThrowingCustomException.java
+++ b/src/test/java/com/societegenerale/aut/test/ObjectThrowingCustomException.java
@@ -1,0 +1,17 @@
+package com.societegenerale.aut.test;
+
+import com.societegenerale.aut.test.exception.CustomException;
+
+public class ObjectThrowingCustomException {
+
+	public void numberBiggerThanTen(int number) throws CustomException {
+		if (number > 10) {
+
+		} else {
+
+			throw new CustomException("The number is not bigger than ten.");
+
+		}
+	}
+
+}

--- a/src/test/java/com/societegenerale/aut/test/ObjectThrowingGenericException.java
+++ b/src/test/java/com/societegenerale/aut/test/ObjectThrowingGenericException.java
@@ -1,0 +1,15 @@
+package com.societegenerale.aut.test;
+
+public class ObjectThrowingGenericException {
+
+	public void numberBiggerThanTen(int number) throws RuntimeException {
+		if (number > 10) {
+
+		} else {
+
+			throw new RuntimeException("The number is not bigger than ten.");
+
+		}
+	}
+
+}

--- a/src/test/java/com/societegenerale/aut/test/exception/CustomException.java
+++ b/src/test/java/com/societegenerale/aut/test/exception/CustomException.java
@@ -1,0 +1,9 @@
+package com.societegenerale.aut.test.exception;
+
+public class CustomException extends RuntimeException {
+
+	public CustomException(String message) {
+		super(message);
+	}
+
+}

--- a/src/test/java/com/societegenerale/commons/plugin/rules/ArchUtilsTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/ArchUtilsTest.java
@@ -1,26 +1,29 @@
 package com.societegenerale.commons.plugin.rules;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
+
+import org.junit.Test;
 
 import com.societegenerale.commons.plugin.SilentLog;
 import com.societegenerale.commons.plugin.utils.ArchUtils;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
-import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * These are not great test, as they will fail when new classes are added in the code base, but acceptable for now
+ * These are not great test, as they will fail when new classes are added in the
+ * code base, but acceptable for now
  */
 public class ArchUtilsTest {
 
-	//instantiating to init the static logger in ArchUtils..
-	ArchUtils archUtils=new ArchUtils(new SilentLog());
+	// instantiating to init the static logger in ArchUtils..
+	ArchUtils archUtils = new ArchUtils(new SilentLog());
 
 	@Test
 	public void shouldLoadClassesFromGivenPackage() {
-		JavaClasses classes = ArchUtils.importAllClassesInPackage("./target/classes/", "com/societegenerale/commons/plugin/model");
+		JavaClasses classes = ArchUtils.importAllClassesInPackage("./target/classes/",
+				"com/societegenerale/commons/plugin/model");
 
 		long noOfClassesInPackage = classes.stream().count();
 
@@ -33,7 +36,7 @@ public class ArchUtilsTest {
 
 		long noOfClasses = classes.stream().filter(it -> !it.isNestedClass()).count();
 
-		assertThat(noOfClasses).isEqualTo(27);
+		assertThat(noOfClasses).isEqualTo(28);
 	}
 
 	@Test
@@ -43,35 +46,35 @@ public class ArchUtilsTest {
 
 		assertThat(classes).isNotEmpty();
 
-		JavaClass classToExclude=classes.stream().filter(c -> c.getSource().get().getUri().toString().contains("ClassToExclude")).findFirst().get();
-		assertThat(classToExclude).as("when no exclusion pattern configured, ClassToExclude should be found").isNotNull();
+		JavaClass classToExclude = classes.stream()
+				.filter(c -> c.getSource().get().getUri().toString().contains("ClassToExclude")).findFirst().get();
+		assertThat(classToExclude).as("when no exclusion pattern configured, ClassToExclude should be found")
+				.isNotNull();
 
-		JavaClasses classesWithTestClassesExclusions = ArchUtils.importAllClassesInPackage("./target", "",Arrays.asList("test-classes"));
+		JavaClasses classesWithTestClassesExclusions = ArchUtils.importAllClassesInPackage("./target", "",
+				Arrays.asList("test-classes"));
 
-		assertThat(containsClassWithPattern(classesWithTestClassesExclusions,"ClassToExclude"))
-				.as("when 'test-classes' pattern configured, ClassToExclude should still be found")
-				.isTrue();
+		assertThat(containsClassWithPattern(classesWithTestClassesExclusions, "ClassToExclude"))
+				.as("when 'test-classes' pattern configured, ClassToExclude should still be found").isTrue();
 
-		assertThat(classes.size())
-				.as("There should be less classes loaded when we apply the test-classes exclusion")
+		assertThat(classes.size()).as("There should be less classes loaded when we apply the test-classes exclusion")
 				.isGreaterThan(classesWithTestClassesExclusions.size());
 
+		JavaClasses classesWithTestClassesAndSpecificExclusions = ArchUtils.importAllClassesInPackage("./target", "",
+				Arrays.asList("test-classes", "ClassToExclude"));
 
-		JavaClasses classesWithTestClassesAndSpecificExclusions = ArchUtils.importAllClassesInPackage("./target", "",Arrays.asList("test-classes","ClassToExclude"));
+		assertThat(containsClassWithPattern(classesWithTestClassesAndSpecificExclusions, "ClassToExclude"))
+				.as("when 'ClassToExclude' pattern configured, ClassToExclude should not  be found").isFalse();
 
-		assertThat(containsClassWithPattern(classesWithTestClassesAndSpecificExclusions,"ClassToExclude"))
-				.as("when 'ClassToExclude' pattern configured, ClassToExclude should not  be found")
-				.isFalse();
-
-		assertThat(classesWithTestClassesAndSpecificExclusions.size()+1)
+		assertThat(classesWithTestClassesAndSpecificExclusions.size() + 1)
 				.as("with a specific exclusion; we should have one less class than without")
 				.isEqualTo(classesWithTestClassesExclusions.size());
 
-
 	}
 
-	private boolean containsClassWithPattern(JavaClasses javaClassesToTest,String pattern){
+	private boolean containsClassWithPattern(JavaClasses javaClassesToTest, String pattern) {
 
-		return javaClassesToTest.stream().filter(c -> c.getSource().get().getUri().toString().contains(pattern)).findFirst().isPresent();
+		return javaClassesToTest.stream().filter(c -> c.getSource().get().getUri().toString().contains(pattern))
+				.findFirst().isPresent();
 	}
 }

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoGenericExceptionRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoGenericExceptionRuleTestTest.java
@@ -1,0 +1,40 @@
+package com.societegenerale.commons.plugin.rules;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.societegenerale.commons.plugin.SilentLog;
+import com.societegenerale.commons.plugin.service.DefaultScopePathProvider;
+import com.societegenerale.commons.plugin.utils.ArchUtils;
+
+public class NoGenericExceptionRuleTestTest {
+
+	String pathObjectThrowingCustomException = "./target/aut-target/test-classes/com/societegenerale/aut/test/ObjectThrowingCustomException.class";
+
+	String pathObjectThrowingGenericException = "./target/aut-target/test-classes/com/societegenerale/aut/test/ObjectThrowingGenericException.class";
+
+	@Before
+	public void setup() {
+		// in the normal lifecycle, ArchUtils is instantiated, which enables a static
+		// field there to be initialized
+		ArchUtils archUtils = new ArchUtils(new SilentLog());
+	}
+
+	@Test(expected = AssertionError.class)
+	public void shouldThrowViolations() {
+
+		new NoGenericExceptionRuleTest().execute(pathObjectThrowingGenericException, new DefaultScopePathProvider());
+
+	}
+
+	@Test
+	public void shouldNotThrowAnyViolation() {
+
+		assertThatCode(() -> new NoGenericExceptionRuleTest().execute(pathObjectThrowingCustomException,
+				new DefaultScopePathProvider())).doesNotThrowAnyException();
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Adding a rule to avoid throwing generic exception

## Details

<!-- Describe your changes in detail -->

1. I created the rule class *NoGenericExceptionRuleTest.java*
2. I created *CustomException.java*
3. I  created *ObjectThrowingCustomException.java*
4. I created *ObjectThrowingGenericException.java*
5. I created the test class *NoGenericExceptionRuleTestTest.java*
6. I modified *ArchUtilsTest.java*

## Context

<!-- Why is this change required? What problem does it solve? -->

It's important to throw specific exceptions than generic exceptions *in order
to get the real source of what's going wrong*. Thus, it's easy to find solutions.
  
 To make you better understand, these 2 links will help you :

- [DontThrowGenericExceptions](https://wiki.c2.com/?DontThrowGenericExceptions)

- [throwing-generic-exception-discouraged](https://stackoverflow.com/questions/7959461/throwing-generic-exception-discouraged)



## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR
