### PR TITLE
Upgrade to ArchUnit 0.15.0 to allow support for Java 15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.version>1.8</java.version>
 
-        <tng.archunit.version>0.13.1</tng.archunit.version>
+        <tng.archunit.version>0.15.0</tng.archunit.version>
 
         <junit.version>4.13.1</junit.version>
         <lombok.version>1.18.10</lombok.version>

--- a/src/main/java/com/societegenerale/commons/plugin/rules/NoJodaTimeRuleTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/NoJodaTimeRuleTest.java
@@ -57,7 +57,9 @@ public class NoJodaTimeRuleTest implements ArchRuleTest {
 
         for(JavaMethodCall methodCall : methodsUsingJodaTimeInternally){
           events.add(SimpleConditionEvent.violated(methodCall.getOriginOwner(), NO_JODA_VIOLATION_MESSAGE
-                  +" - class: "+methodCall.getOriginOwner().getName()+ " - line: "+methodCall.getLineNumber()));
+                  +" - class: "+methodCall.getOriginOwner().getName()
+                  +" - method: "+methodCall.getTarget().getOwner().getSimpleName()+"."+methodCall.getTarget().getName()
+                  +" - line: "+methodCall.getLineNumber()));
         }
       }
 

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoJodaTimeRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoJodaTimeRuleTestTest.java
@@ -34,9 +34,10 @@ public class NoJodaTimeRuleTestTest {
         });
 
         assertThat(validationExceptionThrown).isInstanceOf(AssertionError.class)
-                .hasMessageContaining("was violated (2 times)")
+                .hasMessageContaining("was violated (3 times)")
                 .hasMessageContaining("ObjectWithJodaTimeReferences - field name: jodaDatTime")
-                .hasMessageContaining("ObjectWithJodaTimeReferences - line: 17");
+                .hasMessageContaining("ObjectWithJodaTimeReferences - method: DateTimeFormat.forPattern - line: 17")
+                .hasMessageContaining("ObjectWithJodaTimeReferences - method: DateTimeFormatter.getParser - line: 17");
 
         assertThat(validationExceptionThrown).hasMessageStartingWith("Architecture Violation")
                 .hasMessageContaining(ObjectWithJodaTimeReferences.class.getName())


### PR DESCRIPTION

## Summary

The main goal is to allow support for Java 15, by upgrading to ArchUnit 0.15.0
The version of ArchUnit is upgraded from 0.13.1 to 0.15.0 (as stated in ArchUnit release notes, [support for Java 15 was added in v0.15.0](https://github.com/TNG/ArchUnit/releases/tag/v0.15.0))

## Details

The upgrade of ArchUnit version required also to change an internal rule and its associated test, because ArchUnit behavior has changed when several violations with the exact same message are found : before 0.15.0, only one such violation was kept in the report ; with 0.15.0, each violation is now kept.
This is due to [a modification in ConditionEvents.getFailureMessages()](https://github.com/TNG/ArchUnit/commit/744fd09da0efa8be9419a4140ffa2a79e0e18b8d) returning failure messages previously in a Set<> (hence the removal of duplicated messages), but now in a List<> (hence keeping all messages including the duplicated ones).

## Context

This change allows to analyze code compiled with Java 15. Otherwise, I was getting error messages :
```
Couldn't import class from file:xxx.class
java.lang.IllegalArgumentException: Unsupported class file major version 59
        at com.tngtech.archunit.thirdparty.org.objectweb.asm.ClassReader.<init>(ClassReader.java:195)

```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I've added tests for my code.

> In fact I have modified the existing tests so that they work with ArchUnit 0.15.0 and also previous versions.

- [ ] Documentation has been updated accordingly to this PR

> No documentation update seems necessary

## Related issue : 
<!-- If it fixes an open issue, please link to the issue here. -->
