### PR TITLE
Feature request: ExclusionImportOption supports package excludes #46

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/utils/ExclusionImportOption.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ExclusionImportOption.java
@@ -13,10 +13,17 @@ public class ExclusionImportOption implements ImportOption {
 
     private URI patternToExcludeDirectoryBased;
 
-
     public ExclusionImportOption(@Nonnull final String patternToExclude) {
         // assuming a directory based exclude path
         this.patternToExcludeDirectoryBased = toUri(patternToExclude);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean includes(Location location) {
+        return location != null && !location.contains(patternToExcludeDirectoryBased.toString());
     }
 
     private URI toUri(@Nonnull final String excludePath){
@@ -43,15 +50,6 @@ public class ExclusionImportOption implements ImportOption {
             stringToConvert = stringToConvert.concat(CLASS);
         }
 
-        stringToConvert = stringToConvert.replaceAll("://*", ":/");
         return URI.create(stringToConvert);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean includes(Location location) {
-        return location != null && !location.contains(patternToExcludeDirectoryBased.toString());
     }
 }

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ExclusionImportOption.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ExclusionImportOption.java
@@ -1,22 +1,57 @@
 package com.societegenerale.commons.plugin.utils;
 
+import java.net.URI;
+
+import javax.annotation.Nonnull;
+
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.core.importer.Location;
 
 public class ExclusionImportOption implements ImportOption {
 
-    String patternToExclude;
+    private static final String CLASS = ".class";
 
-    public ExclusionImportOption(String patternToExclude) {
-        this.patternToExclude=patternToExclude;
+    private URI patternToExcludeDirectoryBased;
+
+
+    public ExclusionImportOption(@Nonnull final String patternToExclude) {
+        // assuming a directory based exclude path
+        this.patternToExcludeDirectoryBased = toUri(patternToExclude);
     }
 
+    private URI toUri(@Nonnull final String excludePath){
+        boolean endWithClass = excludePath.endsWith(CLASS);
+        String stringToConvert = excludePath;
+
+        if(excludePath.endsWith(CLASS)) {
+            // remove .class for easier replacements
+            stringToConvert = excludePath.substring(0, excludePath.length() - CLASS.length());
+        }
+
+        // assuming a package based exclude path
+        if(stringToConvert.contains(".")){
+            stringToConvert = stringToConvert.replaceAll("\\Q.\\E", "/");
+        }
+        // assuming a directory based exclude path
+        else {
+            // replace backslash by slash
+            stringToConvert = stringToConvert.replaceAll("\\Q\\\\E", "/");
+        }
+
+        if(endWithClass){
+            // append .class
+            stringToConvert = stringToConvert.concat(CLASS);
+        }
+
+        stringToConvert = stringToConvert.replaceAll("://*", ":/");
+        return URI.create(stringToConvert);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean includes(Location location) {
-
-        if(location.contains(patternToExclude)){
-            return false;
-        }
-        return true;
+        return location != null && !location.contains(patternToExcludeDirectoryBased.toString());
     }
 }

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ExclusionImportOption.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ExclusionImportOption.java
@@ -20,7 +20,7 @@ public class ExclusionImportOption implements ImportOption {
     }
 
     private URI toUri(@Nonnull final String excludePath){
-        boolean endWithClass = excludePath.endsWith(CLASS);
+        boolean excludePathEndsWithDotClass = excludePath.endsWith(CLASS);
         String stringToConvert = excludePath;
 
         if(excludePath.endsWith(CLASS)) {
@@ -30,16 +30,16 @@ public class ExclusionImportOption implements ImportOption {
 
         // assuming a package based exclude path
         if(stringToConvert.contains(".")){
-            stringToConvert = stringToConvert.replaceAll("\\Q.\\E", "/");
+            stringToConvert = stringToConvert.replaceAll("\\.", "/");
         }
         // assuming a directory based exclude path
         else {
             // replace backslash by slash
-            stringToConvert = stringToConvert.replaceAll("\\Q\\\\E", "/");
+            stringToConvert = stringToConvert.replaceAll("\\\\", "/");
         }
 
-        if(endWithClass){
-            // append .class
+        if(excludePathEndsWithDotClass){
+            // appends again .class that we removed initially
             stringToConvert = stringToConvert.concat(CLASS);
         }
 

--- a/src/test/java/com/societegenerale/commons/plugin/utils/ExclusionImportOptionTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/utils/ExclusionImportOptionTest.java
@@ -1,0 +1,113 @@
+package com.societegenerale.commons.plugin.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.tngtech.archunit.core.importer.Location;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ExclusionImportOptionTest {
+
+    private static String excludePathDirectorySlashes     = "com/societegenerale/commons/plugin/utils";
+    private static String excludePathDirectoryBackslashes = "com\\societegenerale\\commons\\plugin\\utils";
+    private static String excludePathPackage              = "com.societegenerale.commons.plugin.utils";
+
+    private static String excludePathClassfileWithSlashes     = "com/societegenerale/commons/plugin/utils/Foo";
+    private static String excludePathClassfileWithBackslashes = "com\\societegenerale\\commons\\plugin\\utils\\Foo";
+    private static String excludePathClassfileWithPackage     = "com.societegenerale.commons.plugin.utils.Foo";
+
+    private static String excludePathClassfileWithTypeAndSlashes     = "com/societegenerale/commons/plugin/utils/Foo.class";
+    private static String excludePathClassfileWithTypeAndBackslashes = "com\\societegenerale\\commons\\plugin\\utils\\Foo.class";
+    private static String excludePathClassfileWithTypeAndPackage     = "com.societegenerale.commons.plugin.utils.Foo.class";
+
+    private static Path testRootDir;
+
+    private static Location locationToBeExclude;
+    private static Location locationToBeIncluded;
+
+
+
+    @BeforeClass
+    public static void init() throws IOException {
+       testRootDir = Files.createTempDirectory("ExclusionImportOptionTest");
+        locationToBeExclude =  Location.of(Paths.get(testRootDir.toString(),"com", "societegenerale", "commons", "plugin", "utils", "Foo.class"));
+        locationToBeIncluded =  Location.of(Paths.get(testRootDir.toString(),"com", "societegenerale", "commons", "plugin", "Bar.class"));
+    }
+
+    @AfterClass
+    public static void cleanUp() throws IOException {
+        if(testRootDir != null){
+            Files.deleteIfExists(testRootDir);
+        }
+    }
+
+    @Test
+    public void includes_LocationNull() {
+        ExclusionImportOption exclusionImportOptionPackage = new ExclusionImportOption("somePattern");
+        assertFalse(exclusionImportOptionPackage.includes(null));
+    }
+
+    @Test
+    public void includes_DirectoryBased() {
+
+        ExclusionImportOption exclusionByDirectoryPatternSlashes = new ExclusionImportOption(
+                excludePathDirectorySlashes);
+        assertFalse(exclusionByDirectoryPatternSlashes.includes(locationToBeExclude));
+        assertTrue(exclusionByDirectoryPatternSlashes.includes(locationToBeIncluded));
+
+        ExclusionImportOption exclusionByDirectoryPatternBackslashes = new ExclusionImportOption(
+                excludePathDirectoryBackslashes);
+        assertFalse(exclusionByDirectoryPatternBackslashes.includes(locationToBeExclude));
+        assertTrue(exclusionByDirectoryPatternBackslashes.includes(locationToBeIncluded));
+    }
+
+    @Test
+    public void includes_PackageBased() {
+        ExclusionImportOption exclusionByPackage = new ExclusionImportOption(excludePathPackage);
+        assertFalse(exclusionByPackage.includes(locationToBeExclude));
+        assertTrue(exclusionByPackage.includes(locationToBeIncluded));
+    }
+
+    @Test
+    public void includes_ClassfileBased() {
+
+        ExclusionImportOption exclusionByClassfileWithSlashes = new ExclusionImportOption(
+                excludePathClassfileWithSlashes);
+        assertFalse(exclusionByClassfileWithSlashes.includes(locationToBeExclude));
+        assertTrue(exclusionByClassfileWithSlashes.includes(locationToBeIncluded));
+
+        ExclusionImportOption exclusionByClassfileWithTypeAndSlashes = new ExclusionImportOption(
+                excludePathClassfileWithTypeAndSlashes);
+        assertFalse(exclusionByClassfileWithTypeAndSlashes.includes(locationToBeExclude));
+        assertTrue(exclusionByClassfileWithTypeAndSlashes.includes(locationToBeIncluded));
+
+        ExclusionImportOption exclusionByClassfileWithBackslashes = new ExclusionImportOption(
+                excludePathClassfileWithBackslashes);
+        assertFalse(exclusionByClassfileWithBackslashes.includes(locationToBeExclude));
+        assertTrue(exclusionByClassfileWithBackslashes.includes(locationToBeIncluded));
+
+        ExclusionImportOption exclusionByClassfileWithTypeAndBackslashes = new ExclusionImportOption(
+                excludePathClassfileWithTypeAndBackslashes);
+        assertFalse(exclusionByClassfileWithTypeAndBackslashes.includes(locationToBeExclude));
+        assertTrue(exclusionByClassfileWithTypeAndBackslashes.includes(locationToBeIncluded));
+    }
+
+    @Test
+    public void includes_ClasspathBased() {
+        ExclusionImportOption exclusionByPackage = new ExclusionImportOption(excludePathClassfileWithPackage);
+        assertFalse(exclusionByPackage.includes(locationToBeExclude));
+        assertTrue(exclusionByPackage.includes(locationToBeIncluded));
+
+        ExclusionImportOption exclusionByTypeAndPackage = new ExclusionImportOption(excludePathClassfileWithTypeAndPackage);
+        assertFalse(exclusionByTypeAndPackage.includes(locationToBeExclude));
+        assertTrue(exclusionByTypeAndPackage.includes(locationToBeIncluded));
+    }
+}

--- a/src/test/java/com/societegenerale/commons/plugin/utils/ExclusionImportOptionTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/utils/ExclusionImportOptionTest.java
@@ -15,35 +15,21 @@ import static org.junit.Assert.assertTrue;
 
 public class ExclusionImportOptionTest {
 
-    private static String excludePathDirectorySlashes     = "com/societegenerale/commons/plugin/utils";
-    private static String excludePathDirectoryBackslashes = "com\\societegenerale\\commons\\plugin\\utils";
-    private static String excludePathPackage              = "com.societegenerale.commons.plugin.utils";
-
-    private static String excludePathClassfileWithSlashes     = "com/societegenerale/commons/plugin/utils/Foo";
-    private static String excludePathClassfileWithBackslashes = "com\\societegenerale\\commons\\plugin\\utils\\Foo";
-    private static String excludePathClassfileWithPackage     = "com.societegenerale.commons.plugin.utils.Foo";
-
-    private static String excludePathClassfileWithTypeAndSlashes     = "com/societegenerale/commons/plugin/utils/Foo.class";
-    private static String excludePathClassfileWithTypeAndBackslashes = "com\\societegenerale\\commons\\plugin\\utils\\Foo.class";
-    private static String excludePathClassfileWithTypeAndPackage     = "com.societegenerale.commons.plugin.utils.Foo.class";
-
     private static Path testRootDir;
 
     private static Location locationToBeExcluded;
     private static Location locationToBeIncluded;
 
-
-
     @BeforeClass
     public static void init() throws IOException {
-       testRootDir = Files.createTempDirectory("ExclusionImportOptionTest");
-        locationToBeExcluded =  Location.of(Paths.get(testRootDir.toString(),"com", "societegenerale", "commons", "plugin", "utils", "Foo.class"));
-        locationToBeIncluded =  Location.of(Paths.get(testRootDir.toString(),"com", "societegenerale", "commons", "plugin", "Bar.class"));
+        testRootDir = Files.createTempDirectory("ExclusionImportOptionTest");
+        locationToBeExcluded = Location.of(Paths.get(testRootDir.toString(), "com", "societegenerale", "commons", "plugin", "utils", "Foo.class"));
+        locationToBeIncluded = Location.of(Paths.get(testRootDir.toString(), "com", "societegenerale", "commons", "plugin", "Bar.class"));
     }
 
     @AfterClass
     public static void cleanUp() throws IOException {
-        if(testRootDir != null){
+        if (testRootDir != null) {
             Files.deleteIfExists(testRootDir);
         }
     }
@@ -56,6 +42,9 @@ public class ExclusionImportOptionTest {
 
     @Test
     public void includes_DirectoryBased() {
+
+        String excludePathDirectorySlashes = "com/societegenerale/commons/plugin/utils";
+        String excludePathDirectoryBackslashes = "com\\societegenerale\\commons\\plugin\\utils";
 
         ExclusionImportOption exclusionByDirectoryPatternSlashes = new ExclusionImportOption(
                 excludePathDirectorySlashes);
@@ -70,6 +59,9 @@ public class ExclusionImportOptionTest {
 
     @Test
     public void includes_PackageBased() {
+
+        String excludePathPackage = "com.societegenerale.commons.plugin.utils";
+
         ExclusionImportOption exclusionByPackage = new ExclusionImportOption(excludePathPackage);
         assertFalse(exclusionByPackage.includes(locationToBeExcluded));
         assertTrue(exclusionByPackage.includes(locationToBeIncluded));
@@ -77,6 +69,12 @@ public class ExclusionImportOptionTest {
 
     @Test
     public void includes_ClassfileBased() {
+
+        String excludePathClassfileWithSlashes = "com/societegenerale/commons/plugin/utils/Foo";
+        String excludePathClassfileWithBackslashes = "com\\societegenerale\\commons\\plugin\\utils\\Foo";
+
+        String excludePathClassfileWithTypeAndSlashes = "com/societegenerale/commons/plugin/utils/Foo.class";
+        String excludePathClassfileWithTypeAndBackslashes = "com\\societegenerale\\commons\\plugin\\utils\\Foo.class";
 
         ExclusionImportOption exclusionByClassfileWithSlashes = new ExclusionImportOption(
                 excludePathClassfileWithSlashes);
@@ -101,6 +99,10 @@ public class ExclusionImportOptionTest {
 
     @Test
     public void includes_ClasspathBased() {
+
+        String excludePathClassfileWithPackage = "com.societegenerale.commons.plugin.utils.Foo";
+        String excludePathClassfileWithTypeAndPackage = "com.societegenerale.commons.plugin.utils.Foo.class";
+
         ExclusionImportOption exclusionByPackage = new ExclusionImportOption(excludePathClassfileWithPackage);
         assertFalse(exclusionByPackage.includes(locationToBeExcluded));
         assertTrue(exclusionByPackage.includes(locationToBeIncluded));

--- a/src/test/java/com/societegenerale/commons/plugin/utils/ExclusionImportOptionTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/utils/ExclusionImportOptionTest.java
@@ -5,11 +5,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import com.tngtech.archunit.core.importer.Location;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import com.tngtech.archunit.core.importer.Location;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -30,7 +29,7 @@ public class ExclusionImportOptionTest {
 
     private static Path testRootDir;
 
-    private static Location locationToBeExclude;
+    private static Location locationToBeExcluded;
     private static Location locationToBeIncluded;
 
 
@@ -38,7 +37,7 @@ public class ExclusionImportOptionTest {
     @BeforeClass
     public static void init() throws IOException {
        testRootDir = Files.createTempDirectory("ExclusionImportOptionTest");
-        locationToBeExclude =  Location.of(Paths.get(testRootDir.toString(),"com", "societegenerale", "commons", "plugin", "utils", "Foo.class"));
+        locationToBeExcluded =  Location.of(Paths.get(testRootDir.toString(),"com", "societegenerale", "commons", "plugin", "utils", "Foo.class"));
         locationToBeIncluded =  Location.of(Paths.get(testRootDir.toString(),"com", "societegenerale", "commons", "plugin", "Bar.class"));
     }
 
@@ -60,19 +59,19 @@ public class ExclusionImportOptionTest {
 
         ExclusionImportOption exclusionByDirectoryPatternSlashes = new ExclusionImportOption(
                 excludePathDirectorySlashes);
-        assertFalse(exclusionByDirectoryPatternSlashes.includes(locationToBeExclude));
+        assertFalse(exclusionByDirectoryPatternSlashes.includes(locationToBeExcluded));
         assertTrue(exclusionByDirectoryPatternSlashes.includes(locationToBeIncluded));
 
         ExclusionImportOption exclusionByDirectoryPatternBackslashes = new ExclusionImportOption(
                 excludePathDirectoryBackslashes);
-        assertFalse(exclusionByDirectoryPatternBackslashes.includes(locationToBeExclude));
+        assertFalse(exclusionByDirectoryPatternBackslashes.includes(locationToBeExcluded));
         assertTrue(exclusionByDirectoryPatternBackslashes.includes(locationToBeIncluded));
     }
 
     @Test
     public void includes_PackageBased() {
         ExclusionImportOption exclusionByPackage = new ExclusionImportOption(excludePathPackage);
-        assertFalse(exclusionByPackage.includes(locationToBeExclude));
+        assertFalse(exclusionByPackage.includes(locationToBeExcluded));
         assertTrue(exclusionByPackage.includes(locationToBeIncluded));
     }
 
@@ -81,33 +80,33 @@ public class ExclusionImportOptionTest {
 
         ExclusionImportOption exclusionByClassfileWithSlashes = new ExclusionImportOption(
                 excludePathClassfileWithSlashes);
-        assertFalse(exclusionByClassfileWithSlashes.includes(locationToBeExclude));
+        assertFalse(exclusionByClassfileWithSlashes.includes(locationToBeExcluded));
         assertTrue(exclusionByClassfileWithSlashes.includes(locationToBeIncluded));
 
         ExclusionImportOption exclusionByClassfileWithTypeAndSlashes = new ExclusionImportOption(
                 excludePathClassfileWithTypeAndSlashes);
-        assertFalse(exclusionByClassfileWithTypeAndSlashes.includes(locationToBeExclude));
+        assertFalse(exclusionByClassfileWithTypeAndSlashes.includes(locationToBeExcluded));
         assertTrue(exclusionByClassfileWithTypeAndSlashes.includes(locationToBeIncluded));
 
         ExclusionImportOption exclusionByClassfileWithBackslashes = new ExclusionImportOption(
                 excludePathClassfileWithBackslashes);
-        assertFalse(exclusionByClassfileWithBackslashes.includes(locationToBeExclude));
+        assertFalse(exclusionByClassfileWithBackslashes.includes(locationToBeExcluded));
         assertTrue(exclusionByClassfileWithBackslashes.includes(locationToBeIncluded));
 
         ExclusionImportOption exclusionByClassfileWithTypeAndBackslashes = new ExclusionImportOption(
                 excludePathClassfileWithTypeAndBackslashes);
-        assertFalse(exclusionByClassfileWithTypeAndBackslashes.includes(locationToBeExclude));
+        assertFalse(exclusionByClassfileWithTypeAndBackslashes.includes(locationToBeExcluded));
         assertTrue(exclusionByClassfileWithTypeAndBackslashes.includes(locationToBeIncluded));
     }
 
     @Test
     public void includes_ClasspathBased() {
         ExclusionImportOption exclusionByPackage = new ExclusionImportOption(excludePathClassfileWithPackage);
-        assertFalse(exclusionByPackage.includes(locationToBeExclude));
+        assertFalse(exclusionByPackage.includes(locationToBeExcluded));
         assertTrue(exclusionByPackage.includes(locationToBeIncluded));
 
         ExclusionImportOption exclusionByTypeAndPackage = new ExclusionImportOption(excludePathClassfileWithTypeAndPackage);
-        assertFalse(exclusionByTypeAndPackage.includes(locationToBeExclude));
+        assertFalse(exclusionByTypeAndPackage.includes(locationToBeExcluded));
         assertTrue(exclusionByTypeAndPackage.includes(locationToBeIncluded));
     }
 }


### PR DESCRIPTION
## Summary

Implementation of Feature request: ExclusionImportOption supports package excludes #46

## Details

ExclusionImportOption is able now to handle a package based exclusion path

## Context

The change is needed for a solution of arch-unit-maven-plugin issues
* https://github.com/societe-generale/arch-unit-maven-plugin/issues/36
* https://github.com/societe-generale/arch-unit-maven-plugin/issues/33


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [ ] Documentation has been updated accordingly to this PR


## Related issue : 
https://github.com/societe-generale/arch-unit-build-plugin-core/issues/46
