### PR TITLE
DontReturnNullCollectionTest tweak 

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTest.java
@@ -1,16 +1,17 @@
 package com.societegenerale.commons.plugin.rules;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
-import javax.annotation.Nonnull;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 
 import com.societegenerale.commons.plugin.service.ScopePathProvider;
 import com.societegenerale.commons.plugin.utils.ArchUtils;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.lang.ArchRule;
-
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
 
 /**
  * Returning null collections (List, Set) forces the caller to always perform a null check, which hinders readability. It's much better to never return a null Collection, and instead return an empty one.
@@ -27,10 +28,37 @@ public class DontReturnNullCollectionTest implements ArchRuleTest {
   @Override
   public void execute(String packagePath, ScopePathProvider scopePathProvider, Collection<String> excludedPaths) {
 
-    ArchRule rule = methods().that().haveRawReturnType(List.class).or().haveRawReturnType(Set.class).should().beAnnotatedWith(Nonnull.class)
-            .because(NO_NULL_COLLECTION_MESSAGE);
+    JavaClasses classesToCheck = ArchUtils.importAllClassesInPackage(scopePathProvider.getMainClassesPath(), packagePath, excludedPaths);
 
-    rule.check(ArchUtils.importAllClassesInPackage(scopePathProvider.getMainClassesPath(), packagePath, excludedPaths));
+    ArchRule rule = methods().that(returnCollections).and(areNotLambdas)
+        .should().beAnnotatedWith(Nonnull.class)
+        .because(NO_NULL_COLLECTION_MESSAGE)
+        .allowEmptyShould(true);
+
+    rule.check(classesToCheck);
   }
+
+  DescribedPredicate<JavaMethod> areNotLambdas =
+      new DescribedPredicate<JavaMethod>("are not lambda"){
+        @Override
+        public boolean apply(JavaMethod input) {
+
+          return !input.getName().contains("lambda$new");
+
+        }
+      };
+
+  DescribedPredicate<JavaMethod> returnCollections =
+      new DescribedPredicate<JavaMethod>("return collections"){
+        @Override
+        public boolean apply(JavaMethod input) {
+
+          Class returnedClass = input.getReturnType().toErasure().reflect();
+
+          return returnedClass.equals(List.class) || returnedClass.equals(Set.class) ;
+
+        }
+      };
+
 
 }

--- a/src/test/java/com/societegenerale/aut/main/ObjectWithLambdasReturningListsInside.java
+++ b/src/test/java/com/societegenerale/aut/main/ObjectWithLambdasReturningListsInside.java
@@ -1,0 +1,22 @@
+package com.societegenerale.aut.main;
+
+import com.google.common.base.Suppliers;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class ObjectWithLambdasReturningListsInside {
+
+	private final Supplier<List<Object>> someCache;
+
+
+	public ObjectWithLambdasReturningListsInside(Supplier<List<Object>> someSupplier) {
+
+		someCache =  Suppliers.memoizeWithExpiration(
+				()-> someSupplier.get(),
+				6, TimeUnit.HOURS);
+
+	}
+
+
+}

--- a/src/test/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTestTest.java
@@ -1,21 +1,23 @@
 package com.societegenerale.commons.plugin.rules;
 
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
 import com.societegenerale.aut.test.TestSpecificScopeProvider;
 import com.societegenerale.commons.plugin.SilentLog;
 import com.societegenerale.commons.plugin.utils.ArchUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import static java.util.Collections.emptySet;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.catchThrowable;
-
 public class DontReturnNullCollectionTestTest {
 
     String pathObjectWithAmethodReturningAnullList = "com/societegenerale/aut/main/ObjectWithMethodsReturningNullCollections.class";
 
     String pathProperlyAnnotatedObjectWithAmethodReturningAlist = "com/societegenerale/aut/main/ObjectWithProperlyAnnotatedMethodsReturningCollections.class";
+
+    String pathObjectWithLambdasReturningListsInside = "com/societegenerale/aut/main/ObjectWithLambdasReturningListsInside.class";
 
     @Before
     public void setup(){
@@ -40,6 +42,16 @@ public class DontReturnNullCollectionTestTest {
 
         assertThatCode(() -> new DontReturnNullCollectionTest().execute(pathProperlyAnnotatedObjectWithAmethodReturningAlist, new TestSpecificScopeProvider(),emptySet()))
                 .doesNotThrowAnyException();
+
+    }
+
+
+    @Test
+    public void shouldNotThrowViolationsOnLambdas() {
+
+        assertThatCode(() -> new DontReturnNullCollectionTest()
+            .execute(pathObjectWithLambdasReturningListsInside, new TestSpecificScopeProvider(),emptySet()))
+            .doesNotThrowAnyException();
 
     }
 }


### PR DESCRIPTION
DontReturnNullCollectionTest tends to raise false positives, as lambdas are considered as methods by Archunit. 

ignoring the lambdas and applying the rule only to other methods