### PR TITLE
making 2 classes serializable

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/model/ApplyOn.java
+++ b/src/main/java/com/societegenerale/commons/plugin/model/ApplyOn.java
@@ -1,7 +1,10 @@
 package com.societegenerale.commons.plugin.model;
 
 
-public class ApplyOn {
+import java.io.Serializable;
+
+public class ApplyOn implements Serializable {
+  static final long serialVersionUID = 1L;
 
   private String packageName;
 

--- a/src/main/java/com/societegenerale/commons/plugin/model/ConfigurableRule.java
+++ b/src/main/java/com/societegenerale/commons/plugin/model/ConfigurableRule.java
@@ -1,8 +1,8 @@
 package com.societegenerale.commons.plugin.model;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -10,7 +10,9 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class ConfigurableRule {
+public class ConfigurableRule implements Serializable {
+
+  static final long serialVersionUID = 1L;
 
   private String rule;
 


### PR DESCRIPTION
making 2 classes serializable, we avoid some complexity in the Gradle plugin, because it's required there.

see https://github.com/societe-generale/arch-unit-gradle-plugin/pull/25#discussion_r877756951