### PR TITLE
revisited implementation for DontReturnNullCollectionTest

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTest.java
@@ -1,19 +1,16 @@
 package com.societegenerale.commons.plugin.rules;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
-import javax.annotation.Nonnull;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 
 import com.societegenerale.commons.plugin.service.ScopePathProvider;
 import com.societegenerale.commons.plugin.utils.ArchUtils;
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.lang.ArchRule;
-
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import java.util.Collection;
+import javax.annotation.Nonnull;
 
 /**
  * Returning null collections (List, Set) forces the caller to always perform a null check, which hinders readability. It's much better to never return a null Collection, and instead return an empty one.
@@ -55,9 +52,10 @@ public class DontReturnNullCollectionTest implements ArchRuleTest {
         @Override
         public boolean apply(JavaMethod input) {
 
-          Class returnedClass = input.getReturnType().toErasure().reflect();
+          JavaClass returnedJavaClass = input.getReturnType().toErasure();
 
-          return returnedClass.equals(List.class) || returnedClass.equals(Set.class) ;
+          return returnedJavaClass.getAllRawInterfaces().stream()
+              .anyMatch(implementedInterface -> implementedInterface.reflect().equals(Collection.class));
 
         }
       };

--- a/src/test/java/com/societegenerale/aut/main/lombok_builder/ObjectWithLombokBuilder.java
+++ b/src/test/java/com/societegenerale/aut/main/lombok_builder/ObjectWithLombokBuilder.java
@@ -1,0 +1,54 @@
+package com.societegenerale.aut.main.lombok_builder;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import lombok.Data;
+
+@Data
+public class ObjectWithLombokBuilder {
+
+	private final String id;
+
+	ObjectWithLombokBuilder(String id) {
+		this.id = id;
+	}
+
+	public static ObjectWithLombokBuilderBuilder builder() {
+		return new ObjectWithLombokBuilderBuilder();
+	}
+
+	@Nonnull
+	public List returningANonNullList(){
+		return emptyList();
+	}
+
+	@Nonnull
+	public Set returningANonNullSet(){
+		return emptySet();
+	}
+
+	public static class ObjectWithLombokBuilderBuilder {
+
+		private String id;
+
+		ObjectWithLombokBuilderBuilder() {
+		}
+
+		public ObjectWithLombokBuilderBuilder id(String id) {
+			this.id = id;
+			return this;
+		}
+
+		public ObjectWithLombokBuilder build() {
+			return new ObjectWithLombokBuilder(id);
+		}
+
+		public String toString() {
+			return "ObjectWithLombokBuilder.ObjectWithLombokBuilderBuilder(id=" + this.id + ")";
+		}
+	}
+}

--- a/src/test/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTestTest.java
@@ -19,6 +19,8 @@ public class DontReturnNullCollectionTestTest {
 
     String pathObjectWithLambdasReturningListsInside = "com/societegenerale/aut/main/ObjectWithLambdasReturningListsInside.class";
 
+    String pathObjectWithLombokBuilder = "com/societegenerale/aut/main/ObjectWithLombokBuilder.class$ObjectWithLombokBuilderBuilder";
+
     @Before
     public void setup(){
         //in the normal lifecycle, ArchUtils is instantiated, which enables a static field there to be initialized
@@ -51,6 +53,15 @@ public class DontReturnNullCollectionTestTest {
 
         assertThatCode(() -> new DontReturnNullCollectionTest()
             .execute(pathObjectWithLambdasReturningListsInside, new TestSpecificScopeProvider(),emptySet()))
+            .doesNotThrowAnyException();
+
+    }
+
+    @Test
+    public void shouldNotThrowViolationsOnClassesUsingLombokBuilder() {
+
+        assertThatCode(() -> new DontReturnNullCollectionTest()
+            .execute("com/societegenerale/aut/main/lombok_builder", new TestSpecificScopeProvider(),emptySet()))
             .doesNotThrowAnyException();
 
     }


### PR DESCRIPTION
changing the way we detect if a method returns a collection or not - previous way was causing some ClassNotFoundException, see https://github.com/TNG/ArchUnit/issues/872

