### PR TITLE
fix: jakarta Nonnull assertion for method returning collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,11 @@
             <version>2.10.0</version>
         </dependency>
 
-
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.1.1</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/DontReturnNullCollectionTest.java
@@ -24,7 +24,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
  */
 public class DontReturnNullCollectionTest implements ArchRuleTest {
 
-  protected static final String NO_NULL_COLLECTION_MESSAGE = "we don't want callers to perform null check every time. Return an empty collection, not null. Please annotate the method with "+Nonnull.class.getCanonicalName();
+  protected static final String NO_NULL_COLLECTION_MESSAGE = "we don't want callers to perform null check every time. Return an empty collection, not null. Please annotate the method with "+Nonnull.class.getCanonicalName()+" or "+ jakarta.annotation.Nonnull.class.getCanonicalName();
 
   @Override
   public void execute(String packagePath, ScopePathProvider scopePathProvider, Collection<String> excludedPaths) {
@@ -33,6 +33,7 @@ public class DontReturnNullCollectionTest implements ArchRuleTest {
 
     ArchRule rule = methods().that(returnCollections).and(areNotLambdas)
         .should().beAnnotatedWith(Nonnull.class)
+        .orShould().beAnnotatedWith(jakarta.annotation.Nonnull.class)
         .because(NO_NULL_COLLECTION_MESSAGE)
         .allowEmptyShould(true);
 

--- a/src/test/java/com/societegenerale/aut/main/ObjectWithProperlyAnnotatedMethodsReturningCollections.java
+++ b/src/test/java/com/societegenerale/aut/main/ObjectWithProperlyAnnotatedMethodsReturningCollections.java
@@ -1,22 +1,30 @@
 package com.societegenerale.aut.main;
 
-import javax.annotation.Nonnull;
-import java.util.List;
-import java.util.Set;
-
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 
+import java.util.List;
+import java.util.Set;
+
 public class ObjectWithProperlyAnnotatedMethodsReturningCollections {
 
-	@Nonnull
-	public List returningANullList(){
+	@jakarta.annotation.Nonnull
+	public List returningANullListWithJakartaNonnullAnnotation(){
 		return emptyList();
 	}
 
-	@Nonnull
-	public Set returningANullSet(){
+	@jakarta.annotation.Nonnull
+	public Set returningANullSetWithJakartaNonnullAnnotation(){
 		return emptySet();
 	}
 
+	@javax.annotation.Nonnull
+	public List returningANullListWithJavaxNonnullAnnotation(){
+		return emptyList();
+	}
+
+	@javax.annotation.Nonnull
+	public Set returningANullSetWithJavaxNonnullAnnotation(){
+		return emptySet();
+	}
 }


### PR DESCRIPTION
## Summary

Basically for rule `DontReturnNullCollectionTest` along with check with `javax.annotation.Nonnull` now due to the movement of javax to jakarta we now have to also check with or condition `jakarta.annotation.Nonnull` 

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Which environnment is/are impacted ? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.


## Related issue : 

Closes: https://github.com/societe-generale/arch-unit-build-plugin-core/issues/74
