### PR TITLE
generalize RuleInvokerService to support 'pom' packaging

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
@@ -1,9 +1,5 @@
 package com.societegenerale.commons.plugin.service;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Collection;
-
 import com.societegenerale.commons.plugin.Log;
 import com.societegenerale.commons.plugin.model.ConfigurableRule;
 import com.societegenerale.commons.plugin.model.RootClassFolder;
@@ -14,9 +10,14 @@ import com.societegenerale.commons.plugin.utils.ArchUtils;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import org.apache.commons.lang3.StringUtils;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import static com.societegenerale.commons.plugin.utils.ReflectionUtils.loadClassWithContextClassLoader;
 import static java.lang.System.lineSeparator;
-import static java.util.Collections.emptySet;
 
 public class RuleInvokerService {
     private static final String EXECUTE_METHOD_NAME = "execute";
@@ -25,30 +26,28 @@ public class RuleInvokerService {
 
     private ArchUtils archUtils;
 
-    private ScopePathProvider scopePathProvider=new DefaultScopePathProvider();
+    private List<ScopePathProvider> scopePathProviders;
 
-    private Collection<String> excludedPaths= emptySet();
+    private Collection<String> excludedPaths;
 
     public RuleInvokerService(Log log) {
-        this.log=log;
-        archUtils =new ArchUtils(log);
+        this(log, new DefaultScopePathProvider(), List.of(), null);
     }
 
     public RuleInvokerService(Log log, ScopePathProvider scopePathProvider) {
-        this.log=log;
-        archUtils =new ArchUtils(log);
-
-        this.scopePathProvider=scopePathProvider;
+        this(log, scopePathProvider, List.of(), null);
     }
 
-    public RuleInvokerService(Log log, ScopePathProvider scopePathProvider,Collection<String> excludedPaths, String projectBuildDir) {
-        this.log=log;
-        archUtils =new ArchUtils(log);
-
-        this.scopePathProvider=scopePathProvider;
-        this.excludedPaths=new ExcludedPathsPreProcessor().processExcludedPaths(log, projectBuildDir, excludedPaths);
+    public RuleInvokerService(Log log, ScopePathProvider scopePathProvider, Collection<String> excludedPaths, String projectBuildDir) {
+        this(log, List.of(scopePathProvider), excludedPaths, projectBuildDir);
     }
 
+    public RuleInvokerService(Log log, List<ScopePathProvider> scopePathProviders, Collection<String> excludedPaths, String projectBuildDir) {
+        this.log = log;
+        this.archUtils = new ArchUtils(log);
+        this.scopePathProviders = scopePathProviders;
+        this.excludedPaths = new ExcludedPathsPreProcessor().processExcludedPaths(log, projectBuildDir, excludedPaths);
+    }
 
     public String invokeRules(Rules rules)
             throws InvocationTargetException, InstantiationException, IllegalAccessException {
@@ -75,19 +74,19 @@ public class RuleInvokerService {
 
         ArchRuleTest ruleToExecute;
 
-        try{
+        try {
             //sometimes, rules need to log - if they do, they should provide a constructor that accepts a Log...
-            ruleToExecute= (ArchRuleTest) ruleClass.getConstructor(Log.class).newInstance(log);
-        }
-        catch(NoSuchMethodException e){
+            ruleToExecute = (ArchRuleTest) ruleClass.getConstructor(Log.class).newInstance(log);
+        } catch (NoSuchMethodException e) {
             //.. otherwise, we use the default constructor with no param
-            ruleToExecute= (ArchRuleTest)ruleClass.newInstance();
+            ruleToExecute = (ArchRuleTest) ruleClass.newInstance();
         }
 
         String errorMessage = "";
         try {
             Method method = ruleClass.getDeclaredMethod(EXECUTE_METHOD_NAME, String.class, ScopePathProvider.class, Collection.class);
-            method.invoke(ruleToExecute, "", scopePathProvider,excludedPaths);
+            // preConfiguredRule only apply for single module
+            method.invoke(ruleToExecute, "", scopePathProviders.get(0), excludedPaths);
         } catch (ReflectiveOperationException re) {
             errorMessage = re.getCause().toString();
         }
@@ -95,47 +94,50 @@ public class RuleInvokerService {
     }
 
     private String invokeConfigurableRules(ConfigurableRule rule) {
-        if(rule.isSkip()) {
-            if(log.isInfoEnabled()) {
+        if (rule.isSkip()) {
+            if (log.isInfoEnabled()) {
                 log.info("Skipping rule " + rule.getRule());
             }
             return "";
         }
 
-        InvokableRules invokableRules = InvokableRules.of(rule.getRule(), rule.getChecks(),log);
+        InvokableRules invokableRules = InvokableRules.of(rule.getRule(), rule.getChecks(), log);
 
-        String fullPathFromRootTopackage = getPackageNameOnWhichToApplyRules(rule);
+        List<String> fullPathFromRootToPackages = getPackageNameOnWhichToApplyRules(rule);
 
-        log.info("invoking ConfigurableRule "+rule.toString()+" on "+fullPathFromRootTopackage);
-        JavaClasses classes = archUtils.importAllClassesInPackage(new RootClassFolder(""), fullPathFromRootTopackage,excludedPaths);
+        log.info("invoking ConfigurableRule " + rule + " on " + fullPathFromRootToPackages);
+        JavaClasses classes = ArchUtils.importAllClassesInPackages(new RootClassFolder(""), fullPathFromRootToPackages, excludedPaths);
 
         InvocationResult result = invokableRules.invokeOn(classes);
         return result.getMessage();
     }
 
-    private String getPackageNameOnWhichToApplyRules(ConfigurableRule rule) {
-
-        StringBuilder packageNameBuilder = new StringBuilder();
+    private List<String> getPackageNameOnWhichToApplyRules(ConfigurableRule rule) {
+        List<String> packageNames = new ArrayList<>();
 
         if (rule.getApplyOn() != null) {
-            if (rule.getApplyOn().getScope() != null && "test".equals(rule.getApplyOn().getScope())) {
-                packageNameBuilder.append(scopePathProvider.getTestClassesPath().getValue());
-            }
-            else{
-                packageNameBuilder.append(scopePathProvider.getMainClassesPath().getValue());
-            }
+            for (ScopePathProvider scopePathProvider : scopePathProviders) {
+                StringBuilder packageNameBuilder = new StringBuilder();
 
-            if(!packageNameBuilder.toString().endsWith("/")){
-                packageNameBuilder.append("/");
-            }
+                if (rule.getApplyOn().getScope() != null && "test".equals(rule.getApplyOn().getScope())) {
+                    packageNameBuilder.append(scopePathProvider.getTestClassesPath().getValue());
+                } else {
+                    packageNameBuilder.append(scopePathProvider.getMainClassesPath().getValue());
+                }
 
-            if (rule.getApplyOn().getPackageName() != null) {
-                packageNameBuilder.append(DotsToSlashesReplacer.replace(rule.getApplyOn().getPackageName()));
-            }
+                if (!packageNameBuilder.toString().endsWith("/")) {
+                    packageNameBuilder.append("/");
+                }
 
+                if (rule.getApplyOn().getPackageName() != null) {
+                    packageNameBuilder.append(DotsToSlashesReplacer.replace(rule.getApplyOn().getPackageName()));
+                }
+
+                packageNames.add(packageNameBuilder.toString());
+            }
         }
 
-        return packageNameBuilder.toString();
+        return packageNames;
     }
 
 

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ArchUtils.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ArchUtils.java
@@ -6,11 +6,14 @@ import com.societegenerale.commons.plugin.Log;
 import com.societegenerale.commons.plugin.model.RootClassFolder;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Created by agarg020917 on 11/17/2017.
@@ -20,69 +23,78 @@ public class ArchUtils {
     private static Log log;
 
     public ArchUtils(Log log) {
-        this.log=log;
+        this.log = log;
     }
 
-    public static JavaClasses importAllClassesInPackage(RootClassFolder rootClassFolder, String packagePath){
-        return importAllClassesInPackage(rootClassFolder, packagePath,emptyList());
+    public static JavaClasses importAllClassesInPackage(RootClassFolder rootClassFolder, String packagePath) {
+        return importAllClassesInPackages(rootClassFolder, List.of(packagePath), emptyList());
     }
 
-    public static JavaClasses importAllClassesInPackage(RootClassFolder rootClassFolder, String packagePath, Collection<String> excludedPaths) {
+    public static JavaClasses importAllClassesInPackage(RootClassFolder rootClassFolder, String packagePaths, Collection<String> excludedPaths) {
+        return importAllClassesInPackages(rootClassFolder, List.of(packagePaths), excludedPaths);
+    }
 
-        //not great design, but since all the rules need to call this, it's very convenient to keep this method static
-        if(log==null){
-            throw new IllegalStateException("please make sure you instantiate "+ArchUtils.class+" with a proper "+Log.class+" before calling this static method");
+    public static JavaClasses importAllClassesInPackages(RootClassFolder rootClassFolder, List<String> packagePaths, Collection<String> excludedPaths) {
+
+        if (log == null) {
+            throw new IllegalStateException("please make sure you instantiate " + ArchUtils.class + " with a proper " + Log.class + " before calling this static method");
         }
 
-        Path classesPath = Paths.get(rootClassFolder.getValue() + packagePath);
+        List<Path> classesPaths = new ArrayList<>();
 
-        if (!classesPath.toFile().exists()) {
-            StringBuilder warnMessage=new StringBuilder("Classpath ").append(classesPath.toFile())
-                    .append(" doesn't exist : loading all classes from root, ie ")
-                    .append(rootClassFolder.getValue())
-                    .append(" even though it's probably not what you want to achieve.")
-                    .append(" Enable debug logs in your build to see the list of actual resources being loaded and analyzed by the plugin.");
-            log.warn(warnMessage.toString());
+        for (String packagePath : packagePaths) {
+            Path classesPath = Paths.get(rootClassFolder.getValue() + packagePath);
 
-            //logging content of directory, to help with debugging..
-            log.debug("existing folders and files under root project : ");
-            try {
-                Files.walk(Paths.get(rootClassFolder.getValue()))
-                        .forEach(f -> log.debug(f.toFile().getName()));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            if (!classesPath.toFile().exists()) {
+                StringBuilder warnMessage = new StringBuilder("Classpath ").append(classesPath.toFile())
+                        .append(" doesn't exist : loading all classes from root, ie ")
+                        .append(rootClassFolder.getValue())
+                        .append(" even though it's probably not what you want to achieve.")
+                        .append(" Enable debug logs in your build to see the list of actual resources being loaded and analyzed by the plugin.");
+                log.warn(warnMessage.toString());
 
-            classesPath= Paths.get(rootClassFolder.getValue());
-        }
-        else{
-            if(log.isDebugEnabled()) {
+                //logging content of directory, to help with debugging..
+                log.debug("existing folders and files under root project : ");
                 try {
-                    log.debug("loading classes from a location that exists : " + classesPath.toFile().getCanonicalPath());
+                    Files.walk(Paths.get(rootClassFolder.getValue()))
+                            .forEach(f -> log.debug(f.toFile().getName()));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    e.printStackTrace();
+                }
+
+                classesPath = Paths.get(rootClassFolder.getValue());
+            } else {
+                if (log.isDebugEnabled()) {
+                    try {
+                        log.debug("loading classes from a location that exists : " + classesPath.toFile().getCanonicalPath());
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             }
+
+            classesPaths.add(classesPath);
         }
 
-        if(log.isDebugEnabled()) {
-            ClassFileImporter classFileImporterForDebug=new ClassFileImporter();
-            JavaClasses classesImportedBeforeExclusion=classFileImporterForDebug.importPath(classesPath);
 
-            log.debug("nb classes imported before exclusion : "+classesImportedBeforeExclusion.size());
+        if (log.isDebugEnabled()) {
+            ClassFileImporter classFileImporterForDebug = new ClassFileImporter();
+            JavaClasses classesImportedBeforeExclusion = classFileImporterForDebug.importPaths(classesPaths);
+
+            log.debug("nb classes imported before exclusion : " + classesImportedBeforeExclusion.size());
         }
 
-        ClassFileImporter classFileImporter=new ClassFileImporter();
+        ClassFileImporter classFileImporter = new ClassFileImporter();
 
-        for(String excludedPath : excludedPaths){
-            ExclusionImportOption exclusionImportOption=new ExclusionImportOption(log,excludedPath);
-            classFileImporter=classFileImporter.withImportOption(exclusionImportOption);
+        for (String excludedPath : excludedPaths) {
+            ExclusionImportOption exclusionImportOption = new ExclusionImportOption(log, excludedPath);
+            classFileImporter = classFileImporter.withImportOption(exclusionImportOption);
         }
 
-        JavaClasses classesImportedAfterExclusionProcessing= classFileImporter.importPath(classesPath);
+        JavaClasses classesImportedAfterExclusionProcessing = classFileImporter.importPaths(classesPaths);
 
-        if(log.isDebugEnabled()) {
-              log.debug("nb classes imported after exclusion : "+classesImportedAfterExclusionProcessing.size());
+        if (log.isDebugEnabled()) {
+            log.debug("nb classes imported after exclusion : " + classesImportedAfterExclusionProcessing.size());
         }
 
         return classesImportedAfterExclusionProcessing;

--- a/src/test/java/com/societegenerale/commons/plugin/rules/ArchUtilsTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/ArchUtilsTest.java
@@ -1,13 +1,14 @@
 package com.societegenerale.commons.plugin.rules;
 
 import java.util.Arrays;
+import java.util.List;
 
 import com.societegenerale.commons.plugin.SilentLog;
 import com.societegenerale.commons.plugin.model.RootClassFolder;
 import com.societegenerale.commons.plugin.utils.ArchUtils;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,6 +29,18 @@ public class ArchUtilsTest {
 		long noOfClassesInPackage = classes.stream().count();
 
 		assertThat(noOfClassesInPackage).isEqualTo(4);
+	}
+
+	@Test
+	public void shouldLoadClassesFromGivenListOfPackages() {
+		JavaClasses classes = ArchUtils.importAllClassesInPackages(new RootClassFolder("./target/classes/"),
+				List.of("com/societegenerale/commons/plugin/model",
+						"com/societegenerale/commons/plugin/utils"),
+				List.of());
+
+		long noOfClassesInPackage = classes.stream().count();
+
+		assertThat(noOfClassesInPackage).isEqualTo(8);
 	}
 
 	@Test

--- a/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
@@ -1,8 +1,5 @@
 package com.societegenerale.commons.plugin.service;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
-
 import com.societegenerale.aut.test.TestSpecificScopeProvider;
 import com.societegenerale.commons.plugin.SilentLog;
 import com.societegenerale.commons.plugin.SilentLogWithMemory;
@@ -14,7 +11,10 @@ import com.societegenerale.commons.plugin.rules.HexagonalArchitectureTest;
 import com.societegenerale.commons.plugin.rules.NoStandardStreamRuleTest;
 import com.societegenerale.commons.plugin.rules.classesForTests.DummyCustomRule;
 import com.tngtech.archunit.library.GeneralCodingRules;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -198,7 +198,7 @@ public class RuleInvokerServiceTest {
 
         ruleInvokerService.invokeRules(rules);
 
-        assertThat(logger.getInfoLogs()).contains("invoking ConfigurableRule "+configurableRule.toString()+" on test/minor-1.2/com/societegenerale/aut/test/specificCase");
+        assertThat(logger.getInfoLogs()).contains("invoking ConfigurableRule "+configurableRule.toString()+" on [test/minor-1.2/com/societegenerale/aut/test/specificCase]");
     }
 
     private class TestSpecificScopeProviderWithDotsInPath  implements ScopePathProvider{


### PR DESCRIPTION
## Summary

Update plugin core to adapt with new version of the plugin that can support run archunit test on 'pom' packaging

## Details

Generalize RuleInvokerService so it can support run archunit test on 'pom' packaging.

## Checklist:

- [x] I've added tests for my code.


## Related issue : 
https://github.com/societe-generale/arch-unit-maven-plugin/issues/55
