### PR TITLE
Add jakarta validation in model domain

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/rules/HexagonalArchitectureTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/HexagonalArchitectureTest.java
@@ -35,6 +35,7 @@ public class HexagonalArchitectureTest implements ArchRuleTest  {
     private static String[] allowedPackageInDomain= {DOMAIN,
             "java..",
             "javax.validation..",
+            "jakarta.validation..",
             "org.slf4j..",
             "lombok..",
             "org.apache.commons.."};

--- a/src/main/java/com/societegenerale/commons/plugin/rules/HexagonalArchitectureTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/HexagonalArchitectureTest.java
@@ -36,6 +36,7 @@ public class HexagonalArchitectureTest implements ArchRuleTest  {
             "java..",
             "javax.validation..",
             "jakarta.validation..",
+            "jakarta.annotation..",
             "org.slf4j..",
             "lombok..",
             "org.apache.commons.."};


### PR DESCRIPTION
## Summary
This merge request aims to incorporate Jakarta validation into the model domain.

## Details

The primary modification involves adding the usage of Jakarta annotations in the model. This transition ensures that the codebase aligns with current practices and utilizes the latest Jakarta technologies.

## Context

With the deprecation of JavaX, Jakarta has become the recommended choice for annotations in the project. By integrating Jakarta validation into the model domain, we enhance the codebase's compatibility with contemporary standards and promote the use of up-to-date technologies.

