### PR TITLE
add configuration switch to disable fallback to root directory

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
@@ -29,6 +29,8 @@ public class RuleInvokerService {
 
     private Collection<String> excludedPaths= emptySet();
 
+    private boolean fallbackToRootDirectory = true;
+
     public RuleInvokerService(Log log) {
         this.log=log;
         archUtils =new ArchUtils(log);
@@ -49,6 +51,14 @@ public class RuleInvokerService {
         this.excludedPaths=new ExcludedPathsPreProcessor().processExcludedPaths(log, projectBuildDir, excludedPaths);
     }
 
+    public RuleInvokerService(Log log, ScopePathProvider scopePathProvider,Collection<String> excludedPaths, String projectBuildDir, boolean fallbackToRootDirectory) {
+        this.log=log;
+        archUtils =new ArchUtils(log);
+
+        this.scopePathProvider=scopePathProvider;
+        this.excludedPaths=new ExcludedPathsPreProcessor().processExcludedPaths(log, projectBuildDir, excludedPaths);
+        this.fallbackToRootDirectory = fallbackToRootDirectory;
+    }
 
     public String invokeRules(Rules rules)
             throws InvocationTargetException, InstantiationException, IllegalAccessException {
@@ -107,7 +117,7 @@ public class RuleInvokerService {
         String fullPathFromRootTopackage = getPackageNameOnWhichToApplyRules(rule);
 
         log.info("invoking ConfigurableRule "+rule.toString()+" on "+fullPathFromRootTopackage);
-        JavaClasses classes = archUtils.importAllClassesInPackage(new RootClassFolder(""), fullPathFromRootTopackage,excludedPaths);
+        JavaClasses classes = archUtils.importAllClassesInPackage(new RootClassFolder(""), fullPathFromRootTopackage, excludedPaths, fallbackToRootDirectory);
 
         InvocationResult result = invokableRules.invokeOn(classes);
         return result.getMessage();

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ArchUtils.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ArchUtils.java
@@ -24,10 +24,14 @@ public class ArchUtils {
     }
 
     public static JavaClasses importAllClassesInPackage(RootClassFolder rootClassFolder, String packagePath){
-        return importAllClassesInPackage(rootClassFolder, packagePath,emptyList());
+        return importAllClassesInPackage(rootClassFolder, packagePath,emptyList(), true);
     }
 
     public static JavaClasses importAllClassesInPackage(RootClassFolder rootClassFolder, String packagePath, Collection<String> excludedPaths) {
+        return importAllClassesInPackage(rootClassFolder, packagePath, excludedPaths, true);
+    }
+
+    public static JavaClasses importAllClassesInPackage(RootClassFolder rootClassFolder, String packagePath, Collection<String> excludedPaths, boolean fallbackToRootDirectory) {
 
         //not great design, but since all the rules need to call this, it's very convenient to keep this method static
         if(log==null){
@@ -36,7 +40,7 @@ public class ArchUtils {
 
         Path classesPath = Paths.get(rootClassFolder.getValue() + packagePath);
 
-        if (!classesPath.toFile().exists()) {
+        if (fallbackToRootDirectory && !classesPath.toFile().exists()) {
             StringBuilder warnMessage=new StringBuilder("Classpath ").append(classesPath.toFile())
                     .append(" doesn't exist : loading all classes from root, ie ")
                     .append(rootClassFolder.getValue())

--- a/src/test/java/com/societegenerale/commons/plugin/rules/ArchUtilsTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/ArchUtilsTest.java
@@ -1,6 +1,7 @@
 package com.societegenerale.commons.plugin.rules;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import com.societegenerale.commons.plugin.SilentLog;
 import com.societegenerale.commons.plugin.model.RootClassFolder;
@@ -37,6 +38,15 @@ public class ArchUtilsTest {
 		long noOfClasses = classes.stream().filter(it -> !it.isNestedClass()).count();
 
 		assertThat(noOfClasses).isEqualTo(36);
+	}
+
+	@Test
+	public void shouldNotLoadAllClassesWhenFallbackIsDisabled() {
+		JavaClasses classes = ArchUtils.importAllClassesInPackage(new RootClassFolder("./target/classes"), "someNotExistingFolder", Collections.emptyList(), false);
+
+		long noOfClasses = classes.stream().filter(it -> !it.isNestedClass()).count();
+
+		assertThat(noOfClasses).isZero();
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Skip analysis for projects without source files

## Details

If no source files are found in a module of a multi module project, no analysis should be done (e.g. in modules which just assemble war files or docker images). Therefor a the configuration property `fallbackToRootDirectory` is added to disable the current default behavior.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Which environnment is/are impacted ? -->

Feature is needed in bigger Maven multi module projects.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR


## Related issue : 
<!-- If it fixes an open issue, please link to the issue here. -->

https://github.com/societe-generale/arch-unit-maven-plugin/issues/66