### PR TITLE
Add support for grouped rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,13 @@
       <version>${tng.archunit.version}</version>
     </dependency>
 
+    <!-- To be able to work with com.tngtech.archunit.junit.ArchTests -->
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-api</artifactId>
+      <version>${tng.archunit.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/DoubleIncludedCustomRule.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/DoubleIncludedCustomRule.java
@@ -1,0 +1,10 @@
+package com.societegenerale.commons.plugin.rules.classesForTests;
+
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+
+public class DoubleIncludedCustomRule {
+
+    @ArchTest
+    static final ArchTests DOUBLE_INCLUDED = ArchTests.in(IncludedCustomRule.class);
+}

--- a/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/IncludedCustomRule.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/IncludedCustomRule.java
@@ -1,0 +1,10 @@
+package com.societegenerale.commons.plugin.rules.classesForTests;
+
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+
+public class IncludedCustomRule {
+
+    @ArchTest
+    static final ArchTests INCLUDED = ArchTests.in(DummyCustomRule.class);
+}

--- a/src/test/java/com/societegenerale/commons/plugin/service/InvokableRulesTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/service/InvokableRulesTest.java
@@ -1,0 +1,75 @@
+package com.societegenerale.commons.plugin.service;
+
+import com.societegenerale.commons.plugin.Log;
+import com.societegenerale.commons.plugin.model.RootClassFolder;
+import com.societegenerale.commons.plugin.rules.classesForTests.DoubleIncludedCustomRule;
+import com.societegenerale.commons.plugin.rules.classesForTests.DummyCustomRule;
+import com.societegenerale.commons.plugin.rules.classesForTests.IncludedCustomRule;
+import com.societegenerale.commons.plugin.utils.ArchUtils;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class InvokableRulesTest {
+
+    @BeforeAll
+    @SuppressWarnings("InstantiationOfUtilityClass")
+    static void instantiateArchUtils() {
+        new ArchUtils(mock(Log.class));
+    }
+
+    @Test
+    void shouldInvokeAllRulesDefinedAsFields() {
+        assertThat(invokeAndGetMessage(DummyCustomRule.class))
+                .contains("Rule 'classes should be annotated with @Test' was violated")
+                .contains("Rule 'classes should reside in a package 'myPackage'' was violated");
+    }
+
+    @Test
+    void shouldInvokeSpecificRuleDefinedAsField() {
+        assertThat(invokeAndGetMessage(DummyCustomRule.class, "annotatedWithTest"))
+                .contains("Rule 'classes should be annotated with @Test' was violated")
+                .doesNotContain("Rule 'classes should reside in a package 'myPackage'' was violated");
+    }
+
+    @Test
+    void shouldInvokeAllRulesIncludedViaField() {
+        assertThat(invokeAndGetMessage(IncludedCustomRule.class))
+                .contains("Rule 'classes should be annotated with @Test' was violated")
+                .contains("Rule 'classes should reside in a package 'myPackage'' was violated");
+    }
+
+    @Test
+    void shouldInvokeSpecificRuleIncludedViaField() {
+        assertThat(invokeAndGetMessage(IncludedCustomRule.class, "annotatedWithTest"))
+                .contains("Rule 'classes should be annotated with @Test' was violated")
+                .doesNotContain("Rule 'classes should reside in a package 'myPackage'' was violated");
+    }
+
+    @Test
+    void shouldInvokeAllRulesIncludedViaFieldThatItselfIncludes() {
+        assertThat(invokeAndGetMessage(DoubleIncludedCustomRule.class))
+                .contains("Rule 'classes should be annotated with @Test' was violated")
+                .contains("Rule 'classes should reside in a package 'myPackage'' was violated");
+    }
+
+    @Test
+    void shouldInvokeSpecificRuleIncludedViaFieldThatItselfIncludes() {
+        assertThat(invokeAndGetMessage(DoubleIncludedCustomRule.class,"annotatedWithTest"))
+                .contains("Rule 'classes should be annotated with @Test' was violated")
+                .doesNotContain("Rule 'classes should reside in a package 'myPackage'' was violated");
+    }
+
+
+    private static String invokeAndGetMessage(Class<?> rulesClass, String... checks) {
+        JavaClasses javaClasses = ArchUtils.importAllClassesInPackage(new RootClassFolder(""), "");
+        InvokableRules invokableRules = InvokableRules.of(rulesClass.getName(), Arrays.asList(checks), mock(Log.class));
+        InvokableRules.InvocationResult invocationResult = invokableRules.invokeOn(javaClasses);
+        return invocationResult.getMessage();
+    }
+}


### PR DESCRIPTION
## Summary

Invoke rules defined by fields of type `ArchTests` which include rules defined in other classes.

See also https://www.archunit.org/userguide/html/000_Index.html#_grouping_rules

Fixes #70

## Details

Extended [InvokableRules](https://github.com/societe-generale/arch-unit-build-plugin-core/blob/master/src/main/java/com/societegenerale/commons/plugin/service/InvokableRules.java) to also support [ArchTests](https://github.com/TNG/ArchUnit/blob/v1.4.0/archunit-junit/src/api/java/com/tngtech/archunit/junit/ArchTests.java).

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Which environnment is/are impacted ? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [ ] Documentation has been updated accordingly to this PR
- ArchUnit documentation already describes grouped rules: https://www.archunit.org/userguide/html/000_Index.html#_grouping_rules


## Related issue : 

https://github.com/societe-generale/arch-unit-build-plugin-core/issues/70
