### PR TITLE
Allow to exclude single checks from a configurable rule

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/model/ConfigurableRule.java
+++ b/src/main/java/com/societegenerale/commons/plugin/model/ConfigurableRule.java
@@ -20,6 +20,8 @@ public class ConfigurableRule implements Serializable {
 
   private List<String> checks = new ArrayList<>();
 
+  private List<String> excludedChecks = new ArrayList<>();
+
   private boolean skip;
 
   public List<String> getChecks() {
@@ -36,6 +38,14 @@ public class ConfigurableRule implements Serializable {
 
   public void setChecks(List<String> checks) {
     this.checks = checks;
+  }
+
+  public List<String> getExcludedChecks() {
+    return excludedChecks;
+  }
+
+  public void setExcludedChecks(List<String> excludedChecks) {
+    this.excludedChecks = excludedChecks;
   }
 
   public ApplyOn getApplyOn() {

--- a/src/main/java/com/societegenerale/commons/plugin/service/InvokableRules.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/InvokableRules.java
@@ -32,7 +32,7 @@ class InvokableRules {
 
     private final Log log;
 
-    private InvokableRules(String rulesClassName, List<String> ruleChecks, Log log) {
+    private InvokableRules(String rulesClassName, List<String> ruleChecks, List<String> excludedChecks, Log log) {
 
         this.log=log;
 
@@ -41,11 +41,13 @@ class InvokableRules {
         Set<Field> allFieldsWhichAreArchRules = getAllFieldsWhichAreArchRules(rulesLocation.getDeclaredFields());
         Set<Method> allMethodsWhichAreArchRules = getAllMethodsWhichAreArchRules(rulesLocation.getDeclaredMethods());
         validateRuleChecks(Sets.union(allMethodsWhichAreArchRules, allFieldsWhichAreArchRules), ruleChecks);
+        validateRuleChecks(Sets.union(allMethodsWhichAreArchRules, allFieldsWhichAreArchRules), excludedChecks);
 
         Predicate<String> isChosenCheck = ruleChecks.isEmpty() ? check -> true : ruleChecks::contains;
+        Predicate<String> isNotExcluded = excludedChecks.isEmpty() ? check -> true : check -> !excludedChecks.contains(check);
 
-        archRuleFields = filterNames(allFieldsWhichAreArchRules, isChosenCheck);
-        archRuleMethods = filterNames(allMethodsWhichAreArchRules, isChosenCheck);
+        archRuleFields = filterNames(allFieldsWhichAreArchRules, isChosenCheck.and(isNotExcluded));
+        archRuleMethods = filterNames(allMethodsWhichAreArchRules, isChosenCheck.and(isNotExcluded));
 
         if(log.isInfoEnabled()) {
             logBuiltInvokableRules(rulesClassName);
@@ -125,8 +127,8 @@ class InvokableRules {
         }
     }
 
-    static InvokableRules of(String rulesClassName, List<String> checks, Log log) {
-        return new InvokableRules(rulesClassName, checks, log);
+    static InvokableRules of(String rulesClassName, List<String> checks, List<String> excludedChecks, Log log) {
+        return new InvokableRules(rulesClassName, checks, excludedChecks, log);
     }
 
     static class InvocationResult {

--- a/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
@@ -112,7 +112,7 @@ public class RuleInvokerService {
             return "";
         }
 
-        InvokableRules invokableRules = InvokableRules.of(rule.getRule(), rule.getChecks(),log);
+        InvokableRules invokableRules = InvokableRules.of(rule.getRule(), rule.getChecks(), rule.getExcludedChecks(), log);
 
         String fullPathFromRootTopackage = getPackageNameOnWhichToApplyRules(rule);
 

--- a/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
@@ -125,6 +125,25 @@ class RuleInvokerServiceTest {
     }
 
     @Test
+    void shouldExcludeConfiguredChecks()
+            throws Exception {
+
+        ApplyOn applyOn = new ApplyOn("com.societegenerale.commons.plugin.rules", "test");
+
+        configurableRule.setRule(DummyCustomRule.class.getName());
+        configurableRule.setApplyOn(applyOn);
+        configurableRule.setExcludedChecks(singletonList("annotatedWithTest"));
+
+        Rules rules = new Rules(emptyList(), Arrays.asList(configurableRule));
+
+        String errorMessage = ruleInvokerService.invokeRules(rules);
+        assertThat(errorMessage).isNotEmpty();
+        assertThat(errorMessage).contains("Architecture Violation");
+        assertThat(errorMessage).doesNotContain("classes should be annotated with @Test");
+        assertThat(errorMessage).contains("classes should reside in a package 'myPackage'");
+    }
+
+    @Test
     void shouldExecuteAllRulesFromConfigurableClassByDefault()
             throws Exception {
 


### PR DESCRIPTION
## Context

Disclaimer: This PR has been implemented with the help of Claude Code.

These changes allow to exclude checks from a configurable rule. This PR is required for https://github.com/societe-generale/arch-unit-maven-plugin/pull/95.

## Related issue

https://github.com/societe-generale/arch-unit-maven-plugin/issues/70